### PR TITLE
:arrow_up: Upgrade python-multipart to `>=0.0.18`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic-settings>=2.5.2",
     "pydantic[email]>=2.9.2",
     "pyjwt>=2.9.0",
-    "python-multipart>=0.0.11",
+    "python-multipart>0.0.18",
     "sqlmodel>=0.0.22",
     "typing-extensions>=4.12.2",
 ]


### PR DESCRIPTION
Avoid versions affected by [CVE-2024-53981](https://github.com/Cxx-mlr/social-media-api/security/dependabot/39)